### PR TITLE
chore: fix examples

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    --example)
+      example_name="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    *) 
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+mkdir build-out
+
+# Verify example name
+if [[ -z $example_name ]]; then
+  echo "example name not specified. Usage: ./build.sh --example <http/mqtt>"
+  exit 1
+fi
+
+# Verify example name is valid
+if [[ $example_name != "http" && $example_name != "mqtt" ]]; then
+  echo "Invalid example name. Please choose either 'http' or 'mqtt'."
+  exit 1
+fi
+
+# Run CMake configure and build
+if [[ $example_name == "http" ]]; then
+    echo "Building HTTP example"
+    cmake -DBUILD_EXAMPLE_WEBSTREAM_RPI_HTTP=ON -DGIT_SUBMODULE_UPDATE=ON -S ./ -B ./build-out
+    cmake --build build-out --target example-w3bstream-client-rpi-http
+    cp ./build-out/examples/w3bstream-client-rpi-http/example-w3bstream-client-rpi-http w3bstream-example
+fi
+
+if [[ $example_name == "mqtt" ]]; then
+    echo "Building MQTT example"
+    cmake -DBUILD_EXAMPLE_WEBSTREAM_RPI_MQTT=ON -DGIT_SUBMODULE_UPDATE=ON -S ./ -B ./build-out
+    cmake --build build-out --target example-w3bstream-client-rpi-mqtt
+    cp ./build-out/examples/w3bstream-client-rpi-mqtt/example-w3bstream-client-rpi-mqtt w3bstream-example
+fi
+
+exit 0

--- a/examples/w3bstream-client-rpi-http/README.md
+++ b/examples/w3bstream-client-rpi-http/README.md
@@ -50,15 +50,15 @@ If everything went correctly, you should see a something along the lines of:
 [100%] Built target example-w3bstream-client-rpi-http
 ```
 
-The build output will be placed inside the `build-output` directory.  
+The build output will be placed inside the `build-out` directory.  
 
 ## Running this example
 
-Change directory to `build-output` and give execution permission to the executable:  
+Change directory to `build-out` and give execution permission to the executable:  
 
 ```bash
-cd build-output/examples/w3bstream-client-rpi-http
-chmod +x example_w3bstream-client-rpi-http
+cd build-out/examples/w3bstream-client-rpi-http
+chmod +x example-w3bstream-client-rpi-http
 ```
 
 Run the executable with the `-h` output to see a description on how to use it:  

--- a/examples/w3bstream-client-rpi-http/main.cpp
+++ b/examples/w3bstream-client-rpi-http/main.cpp
@@ -376,12 +376,12 @@ int main(int argc, char* argv[])
 	// Verify required arguments are present.
 	if (endpoint == "")
 	{
-		std::cerr << "Endpoint is required." << std::endl;
+		std::cerr << "Endpoint is required. Use the -h option for usage instructions." << std::endl;
 		return 1;
 	}
 	if (publisher_token == "")
 	{
-		std::cerr << "Publisher token is required." << std::endl;
+		std::cerr << "Publisher token is required. Use the -h option for usage instructions." << std::endl;
 		return 1;
 	}
 

--- a/examples/w3bstream-client-rpi-mqtt/CMakeLists.txt
+++ b/examples/w3bstream-client-rpi-mqtt/CMakeLists.txt
@@ -12,16 +12,16 @@ set(SOURCES
     ${PROTO_SRCS} ${PROTO_HDRS}
 )
 
-add_executable(w3bstream-client-rpi-mqtt ${SOURCES})
+add_executable(example-w3bstream-client-rpi-mqtt ${SOURCES})
 
-target_include_directories(w3bstream-client-rpi-mqtt
+target_include_directories(example-w3bstream-client-rpi-mqtt
     PRIVATE ${MOSQUITTO_INCLUDE_DIR}
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
     PRIVATE ${NANOPB_INCLUDE_DIRS}
     PRIVATE ext
 )
 
-target_link_libraries(w3bstream-client-rpi-mqtt
+target_link_libraries(example-w3bstream-client-rpi-mqtt
     PRIVATE ${MOSQUITTO_LIBRARIES}
     PRIVATE ws_iot_sdk
 )

--- a/examples/w3bstream-client-rpi-mqtt/README.md
+++ b/examples/w3bstream-client-rpi-mqtt/README.md
@@ -127,7 +127,7 @@ If everything went correctly, you should see a something along the lines of:
 [100%] Built target w3bstream-client-rpi-mqtt
 ```
 
-The build output will be placed inside the `build-output` directory.
+The build output will be placed inside the `build-out` directory.
 
 ## Add public key to wasm
 
@@ -154,12 +154,12 @@ Copy public key(hex string) to the "raspi_pub_key" variable in the dev_test/src/
 
 ## Running this example
 
-Change directory to `build-output`:
+Change directory to `build-out`:
 
 ```bash
 cd web3-iot-sdk/build-out/examples/w3bstream-client-rpi-mqtt
 
-./w3bstream-client-rpi-mqtt  -t w3bstream_token  -T w3bstream_topic
+./example-w3bstream-client-rpi-mqtt  -t w3bstream_token  -T w3bstream_topic
 
 Connecting to the broker at devnet-staging.w3bstream.com ...
 Successfully connnected to the MQTT broker.

--- a/examples/w3bstream-client-rpi-mqtt/main.cpp
+++ b/examples/w3bstream-client-rpi-mqtt/main.cpp
@@ -154,7 +154,6 @@ static char *build_message(psa_key_id_t key_id, unsigned int *len) {
     std::cout << std::endl;
 
 
-    std::cout << "binary_package.data.size :" << binary_package.data.size << std::endl;
     memcpy(binary_package.signature, signature, 64);
     binary_package.timestamp = uint_timestamp;
     binary_package.type = BinaryPackage_PackageType_DATA;
@@ -165,7 +164,6 @@ static char *build_message(psa_key_id_t key_id, unsigned int *len) {
         return 0;
     }
     w3bstream_event.payload.size = enc_packstream.bytes_written;
-    std::cout << "w3bstream_event.payload.size :" << w3bstream_event.payload.size << std::endl;
 
     pb_ostream_t stream = pb_ostream_from_buffer(data, data_buffer_size);
     if (!pb_encode(&stream, Event_fields, &w3bstream_event)) {
@@ -173,7 +171,6 @@ static char *build_message(psa_key_id_t key_id, unsigned int *len) {
         return 0;
     }
     *len = stream.bytes_written;
-    std::cout << "stream.bytes_written :" << stream.bytes_written << std::endl;
     return (char *)data;
 }
 
@@ -364,7 +361,7 @@ int main(int argc, char *argv[]) {
         if (arg == "-h")
 		{
 			std::cout << "NAME" << std::endl;
-			std::cout << "	Web3 IoT SDK example: Raspberry Pi w3bstream client using HTTP." << std::endl;
+			std::cout << "	Web3 IoT SDK example: Raspberry Pi w3bstream client using MQTT." << std::endl;
 			std::cout << "SYNOPSIS" << std::endl;
 			std::cout << "	send_data [-n project_name] [-t w3bstream_token] [-w wallet_address] " << std::endl;
 			std::cout << "DESCRIPTION" << std::endl;
@@ -372,6 +369,8 @@ int main(int argc, char *argv[]) {
 			std::cout << "USAGE" << std::endl;
 			std::cout << "	Run the program specifying the required arguments." << std::endl;
 			std::cout << "	The program will periodically send a message to the w3bstream node and print the message and response to stdout." << std::endl << std::endl;
+            std::cout << "	Example:" << std::endl;
+            std::cout << "		./w3bstream-example -t \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJQYXlsb2FkIjoiOTAyNTg1MTIzODM2OTI4MiIsImlzcyI6InczYnN0cmVhbSJ9.mNbURj_JJpn8nh9K_tvIuQv1hFD4QBBftkPasbx6x_0\" -T \"eth_0x0000835ae09314f5c5a0216ddb0968aa79100001_quick_start\"" << std::endl << std::endl;
 			std::cout << "OPTIONS" << std::endl;
 			std::cout << "	-t  w3bstream_token (required)" << std::endl;
 			std::cout << "		The publisher token. If not specified, an empty publisher token will be used." << std::endl << std::endl;
@@ -383,12 +382,12 @@ int main(int argc, char *argv[]) {
     }
 	if (w3bstream_token == "")
 	{
-		std::cerr << "Publisher token is required." << std::endl;
+		std::cerr << "Publisher token is required. Use the -h option for usage instructions" << std::endl;
 		return 1;
 	}
 	if (w3bstream_topic == "")
 	{
-		std::cerr << "Publisher topic is required." << std::endl;
+		std::cerr << "Publisher topic is required. Use the -h option for usage instructions" << std::endl;
 		return 1;
 	}
 
@@ -428,7 +427,8 @@ int main(int argc, char *argv[]) {
         message = build_message(key_id, &length);
         int res = mosquitto_publish(client, nullptr, w3bstream_topic.c_str(), length, message, 0, false);
         free(message);
-        if (res != MOSQ_ERR_SUCCESS) {
+        if (res != MOSQ_ERR_SUCCESS)
+        {
             std::cerr << "Failed to publish status query MQTT message" << std::endl;
             return ResultCode::ERR_MQTT;
         }


### PR DESCRIPTION
Fixes the examples for consistency and removes unnecesary debug prints
Also adds simplified build.sh script.